### PR TITLE
Medcom integration

### DIFF
--- a/App/src/main/java/engineer/thesis/security/TokenUtils.java
+++ b/App/src/main/java/engineer/thesis/security/TokenUtils.java
@@ -11,9 +11,12 @@ import org.springframework.stereotype.Component;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Base64;
 
 @Component
 public class TokenUtils {
+
+    private static final String encodedKey = Base64.getEncoder().encodeToString("secret_super_secret".getBytes());
 
     private final String AUDIENCE_WEB = "web";
     private final String AUDIENCE_TABLET = "tablet";
@@ -53,7 +56,7 @@ public class TokenUtils {
         return Jwts.builder()
                 .setClaims(claims)
                 .setExpiration(this.generateExpirationDate())
-                .signWith(SignatureAlgorithm.HS256, "secret_super_secret")
+                .signWith(SignatureAlgorithm.HS256, encodedKey)
                 .compact();
     }
 


### PR DESCRIPTION
poprawka w tworzeniu tokenów JWT - potrzebna żeby działała integracja z medcom core

dla pełnej poprawności można by się też później zastanowić czy takie coś nie będzie lepsze:
```
SecretKey key = MacProvider.generateKey(SignatureAlgorithm.HS256);
String encodedKey = TextCodec.BASE64.encode(key.getEncoded());
```